### PR TITLE
Issue #2: Universalize nodejs script shebang.

### DIFF
--- a/juci-build-tpl-cache
+++ b/juci-build-tpl-cache
@@ -1,4 +1,5 @@
-#!/usr/bin/node
+#!/bin/sh
+':' //; exec "$(command -v nodejs || command -v node)" "$0" "$@"
 
 var fs = require("fs"); 
 

--- a/juci-local-server
+++ b/juci-local-server
@@ -1,4 +1,5 @@
-#!/usr/bin/node
+#!/bin/sh
+':' //; exec "$(command -v nodejs || command -v node)" "$0" "$@"
 
 var express = require('express');
 var app = express();

--- a/themes/juci-inteno/juci-theme-build-templates
+++ b/themes/juci-inteno/juci-theme-build-templates
@@ -1,4 +1,5 @@
-#!/usr/bin/node
+#!/bin/sh
+':' //; exec "$(command -v nodejs || command -v node)" "$0" "$@"
 
 var fs = require("fs"); 
 


### PR DESCRIPTION
I had the error described:
```
make[1]: ../juci-build-tpl-cache: Command not found
make[1]: *** [htdocs/js/01-juci-tpl.js] Error 127
make[1]: Leaving directory `/home/alex/Projects/luci-express/juci'
make: *** [juci] Error 2
```

From http://unix.stackexchange.com/questions/65235/universal-node-js-shebang, it looks like this is the best way to guarantee that a javascript script will reference the appropriate node executable. This is especially important considering that some folks use nvm.